### PR TITLE
Ignore enabled swap; Add cgroups-per-qos flag to true

### DIFF
--- a/silverkube.py
+++ b/silverkube.py
@@ -460,6 +460,8 @@ Services: List[Service] = [
             "--kubeconfig",
             str(KUBECONFIG),
             "--register-node=true",
+            "--fail-swap-on=false",
+            "--cgroups-per-qos=true",
             f"--v={VERBOSE}",
         ]
         + (


### PR DESCRIPTION
The kubelet does not want to start if the swap storage
is available on the host. Also 'cgroups-per-qos' set to true
is required to start silverkube on Fedora 33.